### PR TITLE
Fix for multiple tooltips showing after delay's time is up

### DIFF
--- a/tooltip-delay.js
+++ b/tooltip-delay.js
@@ -1,5 +1,7 @@
 (function (H) {
 
+    var timerId;
+
     H.wrap(H.Tooltip.prototype, 'refresh', function (proceed) {
 
 
@@ -9,9 +11,12 @@
         var refreshArguments = arguments;
         var delayForDisplay = chart.options.tooltip.delayForDisplay;
 
+        if (timerId) {
+            clearTimeout(timerId);
+        }
 
         if (delayForDisplay) {
-            window.setTimeout(function () {
+            timerId = window.setTimeout(function () {
 
                 if (point === chart.hoverPoint || $.inArray(chart.hoverPoint, point) > -1) {
                     proceed.apply(tooltip, Array.prototype.slice.call(refreshArguments, 1));


### PR DESCRIPTION
Currently, if you're hovering over multiple points in a data series, when the `delayForDisplay` has elapsed, the tooltip for *all* the hovered-on points display in succession. This fix makes only the last-hovered point's tooltip display. Therefore, if you hover over 10 points, after `delayForDisplay` has elapsed, you won't see 10 tooltips suddenly display--you'll only see the last one.