### PR TITLE
The "delayForDisplay" variable now has a default value of 1000ms

### DIFF
--- a/tooltip-delay.js
+++ b/tooltip-delay.js
@@ -9,24 +9,20 @@
         var chart = this.chart;
         var tooltip = this;
         var refreshArguments = arguments;
-        var delayForDisplay = chart.options.tooltip.delayForDisplay;
+        var delayForDisplay = chart.options.tooltip.delayForDisplay : chart.options.tooltip.delayForDisplay ? 1000;
 
         if (timerId) {
             clearTimeout(timerId);
         }
 
-        if (delayForDisplay) {
-            timerId = window.setTimeout(function () {
+        timerId = window.setTimeout(function () {
 
-                if (point === chart.hoverPoint || $.inArray(chart.hoverPoint, point) > -1) {
-                    proceed.apply(tooltip, Array.prototype.slice.call(refreshArguments, 1));
-                }
+            if (point === chart.hoverPoint || $.inArray(chart.hoverPoint, point) > -1) {
+                proceed.apply(tooltip, Array.prototype.slice.call(refreshArguments, 1));
+            }
 
-            }, delayForDisplay || 1000);
-        } else {
-            proceed.apply(tooltip, Array.prototype.slice.call(refreshArguments, 1));
-        }
-
+        }, delayForDisplay);
+ 
     });
 
 }(Highcharts));


### PR DESCRIPTION
The "delayForDisplay" variable now has a default value of 1000ms if one is not specified by a user in the chart's options.  Fix made in reference to the issue here: https://github.com/rudovjan/highcharts-tooltip-delay/issues/3